### PR TITLE
Provides basis for count meaurement data of unclassified fragments of neural arches and vertebral bodies

### DIFF
--- a/phaleron-si.owl
+++ b/phaleron-si.owl
@@ -13502,7 +13502,7 @@
                             <owl:Restriction>
                                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
                                 <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
-                                <owl:onClass rdf:resource="http://w3id.org/rdfbones/ext/phaleron-si/EntireBodyOfVertebra"/>
+                                <owl:onClass rdf:resource="http://w3id.org/rdfbones/core#EntireSetOfAllVertebralBodies"/>
                             </owl:Restriction>
                         </owl:intersectionOf>
                     </owl:Class>
@@ -13570,7 +13570,7 @@
                             <owl:Restriction>
                                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
                                 <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
-                                <owl:onClass rdf:resource="http://w3id.org/rdfbones/ext/phaleron-si/EntireNeuralArchOfVertebra"/>
+                                <owl:onClass rdf:resource="http://w3id.org/rdfbones/core#EntireSetOfAllNeuralArches"/>
                             </owl:Restriction>
                         </owl:intersectionOf>
                     </owl:Class>


### PR DESCRIPTION
This corrects restrictions on the vertebral column section class prescribing counts of unclassified fragments of neural arches and vertebral bodies as called for by issue https://github.com/RDFBones/RDFBonesPhaleron/issues/52.